### PR TITLE
Fix byte-compile warnings

### DIFF
--- a/sniem-common.el
+++ b/sniem-common.el
@@ -25,6 +25,8 @@
 
 ;;; Code:
 
+(require 'subr-x)
+
 (require 'sniem-var)
 
 (declare-function sniem-show-last-point "sniem")

--- a/sniem.el
+++ b/sniem.el
@@ -42,6 +42,8 @@
 (require 'sniem-macro)
 (require 'sniem-operation)
 
+(eval-when-compile
+  (defvar awesome-tray-module-alist))
 
 (define-minor-mode sniem-mode
   "Simple united editing method mode."


### PR DESCRIPTION
```
sniem-common.el:129:1:Warning: the function ‘string-empty-p’ is not known to
    be defined.

sniem.el:449:17:Warning: reference to free variable
    ‘awesome-tray-module-alist’
sniem.el:449:17:Warning: assignment to free variable
    ‘awesome-tray-module-alist’
```
